### PR TITLE
DRAFT: Add configurable ident token to the user agent

### DIFF
--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2012 Anaconda, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
+import base64
 from collections import OrderedDict
 
 from errno import ENOENT
@@ -9,6 +10,7 @@ from itertools import chain
 from logging import getLogger
 from typing import Optional
 import os
+import re
 from os.path import abspath, expanduser, isdir, isfile, join, split as path_split
 import platform
 import sys
@@ -94,6 +96,95 @@ _arch_names = {
 
 user_rc_path = abspath(expanduser('~/.condarc'))
 sys_rc_path = join(sys.prefix, '.condarc')
+
+
+_client_token_formats = {
+    'none': '',
+    'random': 'cs',
+    'client': 'cs',
+    'session': 's',
+    'username': 'ucs',
+    'hostname': 'hcs',
+    'userhost': 'uhcs'
+}
+_client_token = None
+_session_token = None
+_user_agent_uuid = None
+
+
+def _reset_tokens():
+    global _client_token
+    global _session_token
+    global _user_agent_uuid
+    _client_token = None
+    _session_token = None
+    _user_agent_uuid = None
+
+
+def _random_token(nchar):
+    nbytes = (nchar * 6 - 1) // 8 + 1
+    return base64.b64encode(os.urandom(nbytes))[:nchar].decode('ascii')
+
+
+def _get_client_token():
+    global _client_token
+    if _client_token is not None:
+        return _client_token
+    cid_file = join(expanduser('~/.conda'), 'client_token')
+    if os.path.exists(cid_file):
+        try_save = False
+        try:
+            # Use just the first line of the file, if it exists
+            _client_token = ''.join(open(cid_file).read().splitlines()[:1])
+            log.debug('Retrieved client token: %s', _client_token)
+        except Exception as exc:
+            log.debug('Unexpected error reading client token: %s', exc)
+    else:
+        _client_token = _random_token(8)
+        log.debug('Generated new client token: %s', _client_token)
+        try:
+            with open(cid_file, 'w') as fp:
+                fp.write(_client_token)
+                fp.write('''
+The code above was generated randomly and contains
+no user identifiable content. Conda servers use this
+to better understand individual behavior patterns.''')
+            log.debug('Client token saved: %s', cid_file)
+        except Exception as exc:
+            log.debug('Unexpected error writing client token file: %s', exc)
+    return _client_token
+
+
+def _get_session_token():
+    global _session_token
+    if _session_token is not None:
+        return _session_token
+    _session_token = _random_token(8)
+    log.debug('Session token generated: %s', _session_token)
+    return _session_token
+
+
+def get_user_agent_uuid():
+    global _user_agent_uuid
+    if _user_agent_uuid is not None:
+        return _user_agent_uuid
+    parts = []
+    fmt = str(context.client_token).lower()
+    fmt = _client_token_formats.get(fmt, fmt)
+    for code in fmt:
+        if code == 'c':
+            value = _get_client_token()
+        elif code == 's':
+            value = _get_session_token()
+        elif code == 'u':
+            value = os.getlogin()
+        elif code == 'h':
+            value = platform.node()
+        else:
+            value = ''
+        parts.append(code + ':' + value)
+    _user_agent_uuid = ':'.join(parts)
+    return _user_agent_uuid
 
 
 def mockable_context_envs_dirs(root_writable, root_prefix, _envs_dirs):
@@ -259,6 +350,7 @@ class Context(Configuration):
     remote_read_timeout_secs = ParameterLoader(PrimitiveParameter(60.))
     remote_max_retries = ParameterLoader(PrimitiveParameter(3))
     remote_backoff_factor = ParameterLoader(PrimitiveParameter(1))
+    client_token = ParameterLoader(PrimitiveParameter("random"))
 
     add_anaconda_token = ParameterLoader(PrimitiveParameter(True), aliases=('add_binstar_token',))
 
@@ -859,7 +951,12 @@ class Context(Configuration):
                     exc_info=exc
                 )
             builder.append(user_agent_str)
-        return " ".join(builder)
+        client_token = get_user_agent_uuid()
+        if client_token:
+            builder.append('token/' + client_token)
+        result = " ".join(builder)
+        log.debug('Generated user agent string: %s', result)
+        return result
 
     @contextmanager
     def _override(self, key, value):
@@ -994,6 +1091,7 @@ class Context(Configuration):
                 "remote_backoff_factor",
                 "remote_read_timeout_secs",
                 "ssl_verify",
+                "client_token",
             ),
             "Solver Configuration": (
                 "aggressive_update_packages",
@@ -1614,6 +1712,15 @@ class Context(Configuration):
                 to 5. In order to completely suppress channel notices, set this to 0.
                 """
             ),
+            client_token=dals(
+                """
+                Specifies the type of code, if any, to add to the user agent, enabling servers
+                to differentiate between different users. The default is "random", for which
+                conda creates a short random string with no user identifiable content, useful
+                for counting or disaggregation purposes. Other choices include "username",
+                "hostname", and "none".
+                """
+            )
         )
 
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -142,17 +142,19 @@ def _get_client_token():
             log.debug('Unexpected error reading client token: %s', exc)
     else:
         _client_token = _random_token(8)
-        log.debug('Generated new client token: %s', _client_token)
         try:
             with open(cid_file, 'w') as fp:
                 fp.write(_client_token)
                 fp.write('''
-The code above was generated randomly and contains
-no user identifiable content. Conda servers use this
-to better understand individual behavior patterns.''')
+This randomly-generated code contains no information about your
+system, location, or username. Conda servers can use this to
+disaggregate download histories, providing a richer data set
+for the analysis of usage behavior patterns.''')
+            log.debug('Generated new client token: %s', _client_token)
             log.debug('Client token saved: %s', cid_file)
         except Exception as exc:
             log.debug('Unexpected error writing client token file: %s', exc)
+            _client_token = ''
     return _client_token
 
 

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from errno import ENOENT
 from functools import lru_cache
+import getpass
 from itertools import chain
 from logging import getLogger
 from typing import Optional
@@ -177,7 +178,7 @@ def get_user_agent_uuid():
         elif code == 's':
             value = _get_session_token()
         elif code == 'u':
-            value = os.getlogin()
+            value = getpass.getuser()
         elif code == 'h':
             value = platform.node()
         else:

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -110,16 +110,6 @@ _client_token_formats = {
 }
 _client_token = None
 _session_token = None
-_user_agent_uuid = None
-
-
-def _reset_tokens():
-    global _client_token
-    global _session_token
-    global _user_agent_uuid
-    _client_token = None
-    _session_token = None
-    _user_agent_uuid = None
 
 
 def _random_token(nchar):
@@ -165,35 +155,6 @@ def _get_session_token():
     _session_token = _random_token(8)
     log.debug('Session token generated: %s', _session_token)
     return _session_token
-
-
-def get_user_agent_uuid():
-    global _user_agent_uuid
-    if _user_agent_uuid is not None:
-        return _user_agent_uuid
-    parts = []
-    fmt = str(context.client_token).lower()
-    fmt = _client_token_formats.get(fmt, fmt)
-    for code in fmt:
-        value = ''
-        if code == 'c':
-            value = _get_client_token()
-        elif code == 's':
-            value = _get_session_token()
-        elif code == 'u':
-            try:
-                value = getpass.getuser()
-            except Exception as exc:
-                log.debug('getpass.getuser raised an exception: %s' % exc)
-        elif code == 'h':
-            value = platform.node()
-            if not value:
-                log.debug('platform.node returned an empty value')
-        if value:
-            parts.append(code + ':' + value)
-    _user_agent_uuid = ':'.join(parts)
-    log.debug('User agent uuid: %s', _user_agent_uuid)
-    return _user_agent_uuid
 
 
 def mockable_context_envs_dirs(root_writable, root_prefix, _envs_dirs):
@@ -940,6 +901,32 @@ class Context(Configuration):
         return 2 if self.debug else self._verbosity
 
     @memoizedproperty
+    def client_token_value(self):
+        parts = []
+        fmt = str(self.client_token).lower()
+        fmt = _client_token_formats.get(fmt, fmt)
+        for code in fmt:
+            value = ''
+            if code == 'c':
+                value = _get_client_token()
+            elif code == 's':
+                value = _get_session_token()
+            elif code == 'u':
+                try:
+                    value = getpass.getuser()
+                except Exception as exc:
+                    log.debug('getpass.getuser raised an exception: %s' % exc)
+            elif code == 'h':
+                value = platform.node()
+                if not value:
+                    log.debug('platform.node returned an empty value')
+            if value:
+                parts.append(code + ':' + value)
+        result = ':'.join(parts)
+        log.debug('Client token: %s', result)
+        return result
+
+    @memoizedproperty
     def user_agent(self):
         builder = [f"conda/{CONDA_VERSION} requests/{self.requests_version}"]
         builder.append("%s/%s" % self.python_implementation_name_version)
@@ -960,9 +947,9 @@ class Context(Configuration):
                     exc_info=exc
                 )
             builder.append(user_agent_str)
-        client_token = get_user_agent_uuid()
-        if client_token:
-            builder.append('token/' + client_token)
+        token = self.client_token_value
+        if token:
+            builder.append('token/' + token)
         result = " ".join(builder)
         log.debug('Generated user agent string: %s', result)
         return result

--- a/conda/base/context.py
+++ b/conda/base/context.py
@@ -124,7 +124,7 @@ def _reset_tokens():
 
 def _random_token(nchar):
     nbytes = (nchar * 6 - 1) // 8 + 1
-    return base64.b64encode(os.urandom(nbytes))[:nchar].decode('ascii')
+    return base64.urlsafe_b64encode(os.urandom(nbytes))[:nchar].decode('ascii')
 
 
 def _get_client_token():
@@ -173,18 +173,24 @@ def get_user_agent_uuid():
     fmt = str(context.client_token).lower()
     fmt = _client_token_formats.get(fmt, fmt)
     for code in fmt:
+        value = ''
         if code == 'c':
             value = _get_client_token()
         elif code == 's':
             value = _get_session_token()
         elif code == 'u':
-            value = getpass.getuser()
+            try:
+                value = getpass.getuser()
+            except Exception as exc:
+                log.debug('getpass.getuser raised an exception: %s' % exc)
         elif code == 'h':
             value = platform.node()
-        else:
-            value = ''
-        parts.append(code + ':' + value)
+            if not value:
+                log.debug('platform.node returned an empty value')
+        if value:
+            parts.append(code + ':' + value)
     _user_agent_uuid = ':'.join(parts)
+    log.debug('User agent uuid: %s', _user_agent_uuid)
     return _user_agent_uuid
 
 

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -17,7 +17,6 @@ from conda.auxlib.ish import dals
 from conda.base.constants import PathConflict, ChannelPriority
 from conda.base.context import (
     context,
-    _reset_tokens,
     reset_context,
     conda_tests_ctxt_mgmt_def_pol,
     validate_prefix_name,
@@ -464,26 +463,24 @@ class ContextCustomRcTests(TestCase):
         pkgs_dirs = _get_expandvars_context("pkgs_dirs", "['${TEST_VAR}']", "/foo")
         assert any("foo" in d for d in pkgs_dirs)
 
-    def test_user_agent_token(self):
+    def test_client_token(self):
         for param, test_fields in (
             ('none', ''), ('', ''), ('random', 'cs'), ('client', 'cs'), ('session', 's'),
             ('hostname', 'hcs'), ('username', 'ucs'), ('userhost', 'uhcs'),
             ('c', 'c'), ('s', 's'), ('u', 'u'), ('h', 'h')):
             if test_fields:
-                # This generates a regexp to test for the presence of a token/ section
-                # of the user agent containing the requested fields.
                 test_re = [c + ':[^:]+' for c in test_fields]
-                test_re = '^.*token/' + ':'.join(test_re) + '$'
+                test_re_ct = '^' + ':'.join(test_re) + '$'
+                test_re_ua = '^.*token/' + ':'.join(test_re) + '$'
             else:
-                # This is a negative lookahead designed to ensure that the token field
-                # is absent from the user agent if "client_token: none" is selected. 
-                test_re = '^((?!token/).)*$'
+                test_re_ct = '^$'
+                test_re_ua = '^((?!token/).)*$'
             string = f"client_token: {param}"
             reset_context()
-            _reset_tokens()
             rd = odict(testdata=YamlRawParameter.make_raw_parameters('testdata', yaml_round_trip_load(string)))
             context._set_raw_data(rd)
-            assert re.match(test_re, context.user_agent), (param, test_fields)
+            assert re.match(test_re_ua, context.user_agent), (param, test_fields)
+            assert re.match(test_re_ct, context.client_token_value), (param, test_fields)
 
 
 class ContextDefaultRcTests(TestCase):

--- a/tests/base/test_context.py
+++ b/tests/base/test_context.py
@@ -6,6 +6,7 @@ from itertools import chain
 import os
 from os.path import join, abspath
 from pathlib import Path
+import re
 from tempfile import gettempdir
 from unittest import TestCase, mock
 
@@ -16,6 +17,7 @@ from conda.auxlib.ish import dals
 from conda.base.constants import PathConflict, ChannelPriority
 from conda.base.context import (
     context,
+    _reset_tokens,
     reset_context,
     conda_tests_ctxt_mgmt_def_pol,
     validate_prefix_name,
@@ -461,6 +463,27 @@ class ContextCustomRcTests(TestCase):
 
         pkgs_dirs = _get_expandvars_context("pkgs_dirs", "['${TEST_VAR}']", "/foo")
         assert any("foo" in d for d in pkgs_dirs)
+
+    def test_user_agent_token(self):
+        for param, test_fields in (
+            ('none', ''), ('', ''), ('random', 'cs'), ('client', 'cs'), ('session', 's'),
+            ('hostname', 'hcs'), ('username', 'ucs'), ('userhost', 'uhcs'),
+            ('c', 'c'), ('s', 's'), ('u', 'u'), ('h', 'h')):
+            if test_fields:
+                # This generates a regexp to test for the presence of a token/ section
+                # of the user agent containing the requested fields.
+                test_re = [c + ':[^:]+' for c in test_fields]
+                test_re = '^.*token/' + ':'.join(test_re) + '$'
+            else:
+                # This is a negative lookahead designed to ensure that the token field
+                # is absent from the user agent if "client_token: none" is selected. 
+                test_re = '^((?!token/).)*$'
+            string = f"client_token: {param}"
+            reset_context()
+            _reset_tokens()
+            rd = odict(testdata=YamlRawParameter.make_raw_parameters('testdata', yaml_round_trip_load(string)))
+            context._set_raw_data(rd)
+            assert re.match(test_re, context.user_agent), (param, test_fields)
 
 
 class ContextDefaultRcTests(TestCase):


### PR DESCRIPTION
This addition to conda inserts a `token/` field into the user-agent string used by conda which can be finely configured depending upon the privacy preferences of the user or administrator. This token allows for better server side logging and analytics by simplifying the disaggregation of accesses among users/clients and individual conda calls.

At its core, it can include any combination of the following four elements:

- `s`:   a 8-character random string generated for each unique call to conda.
- `c`: an 8-character random string generated for each client/user of conda. This token is generated once and saved in `~/.conda/client_token` along with explanatory text that it contains no user information.
- `u`: the username as determined by `getpass.getuser()`.
- `h`: the local hostname as determined by `platform.node()`.

The configuration parameter `client_token` controls which of these elements is included in the user agent. Possible values include:

- `none`: no elements are included.
- `random`: `c` and `s`;
- `client`: `c` and `s` (synonymous with `random`);
- `session`: `s` only;
- `username`: `u`, `c`, and `s`;
- `hostname`: `h`, `c`, and `s`;
- `userhost`: `u`, `h`, `c`, and `s`
- any combination of the letters `uhcs` can be used as well.

The default value of this parameter be set to `random`. This provides the maximum amount of anonymized disaggregation possible. Of course, it is essential that we offer the lower-information options, including `none`, as well. The unit tests include a test to ensure that there is no `token/` field present when the `none` option is selected.

We do not anticipate that community users will want to set `client_token` to include the non-anonymous username and hostname information. However, there will be many business settings where this information can be tremendously useful. For instance, if properly logged, this information can be used to:
- significantly improve an administrator's ability to determine which users have downloaded packages that have been flagged for removal due to vulnerabilities.
- provide a more accurate count of the number of unique users in an organization are using an internal repository.

Here are some examples of the user agent string for various values of these parameters. These were generated by the unit tests. Note that the client token is identical across those examples that contain it; but the session token is different in each.

- `none`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2
: conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2`
- `random`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2 token/c:JROgxZYi:s:PE8q7Q3L`
- `client`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2 token/c:JROgxZYi:s:1msOlxR0`
- `session`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2 token/s:gTzF+a1i`
- `hostname`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2 token/h:m1mbp.local:c:JROgxZYi:s:ihmOiH0x`
- `username`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2 token/u:mgrant:c:JROgxZYi:s:I6HefalU`
- `userhost`: `conda/22.11.1.post13+449ed5921 requests/2.28.1 CPython/3.8.15 Darwin/21.6.0 OSX/12.6.2 token/u:mgrant:h:m1mbp.local:c:JROgxZYi:s:6kwmynVB`
